### PR TITLE
Update thirdwebsdk.mdx: fixing the options paragraphs formatting

### DIFF
--- a/docs/unity/thirdwebsdk.mdx
+++ b/docs/unity/thirdwebsdk.mdx
@@ -108,8 +108,6 @@ ThirdwebSDK sdk = new ThirdwebSDK("goerli", 5);
 To use the Unity SDK, you need to pass a `clientId` option which you can obtain from an API key from the [Dashboard](https://thirdweb.com/dashboard).
 :::
 
-````csharp
-
 You can use [gasless transactions](/glossary/gasless-transactions) to forward all transactions to a relayer.
 
 Currently supports [OpenZeppelin Defender](https://blog.thirdweb.com/guides/setup-gasless-transactions/) relayers.
@@ -163,4 +161,4 @@ ThirdwebSDK sdk = new ThirdwebSDK("goerli", 5, new ThirdwebSDK.Options()
         entryPointAddress = "entry-point-address" // The address of the entry point contract (optional)
     }
 });
-````
+```


### PR DESCRIPTION
Edit formatting under the *options*, get out of the csharp snippet code for 2 of the paragraphs after the info.